### PR TITLE
If no argument is specified, use the current commandline as the query

### DIFF
--- a/peco_select_history.fish
+++ b/peco_select_history.fish
@@ -1,6 +1,6 @@
 function peco_select_history
   if test (count $argv) = 0
-    set peco_flags --layout=bottom-up
+    set peco_flags --layout=bottom-up --qeury "(commandline)"
   else
     set peco_flags --layout=bottom-up --query "$argv"
   end


### PR DESCRIPTION
This behavior matches my expectations better, I guess because this is also how `C-r` works in bash.
